### PR TITLE
Drop babel-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "cashay": "^0.21.0",
+    "cashay": "^0.22.0",
     "ember-ajax": "^2.4.1",
     "ember-browserify": "^1.1.13",
     "ember-cli": "2.9.1",
@@ -49,7 +49,6 @@
     "ember-addon"
   ],
   "dependencies": {
-    "babel-runtime": "^6.18.0",
     "broccoli-cashay-schema": "^0.2.4",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
@@ -57,9 +56,9 @@
     "ember-fetch": "1.3.0"
   },
   "peerDependencies": {
-    "cashay": "^0.21.0",
+    "cashay": "^0.22.0",
     "ember-browserify": "^1.1.13",
-    "ember-redux": "^1.7.0",
+    "ember-redux": "^1.9.0",
     "graphql": "^0.7.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"


### PR DESCRIPTION
No longer needed.  Requirement was dropped upstream.  See https://github.com/mattkrick/cashay/pull/140.