### PR TITLE
Drop babel runtime

### DIFF
--- a/blueprints/ember-cashay/index.js
+++ b/blueprints/ember-cashay/index.js
@@ -8,13 +8,11 @@ module.exports = {
     return this.addAddonsToProject({
       packages: [
         { name: 'ember-browserify', target: '^1.1.13' },
-        { name: 'ember-redux', target: '^1.6.0' }
+        { name: 'ember-redux', target: '^1.9.0' }
       ]
     }).then(function() {
       return this.addPackagesToProject([
-        // TODO: Remove babel-runtime from host if possible
-        { name: 'babel-runtime', target: '^6.18.0' },
-        { name: 'cashay', target: '^0.20.12' },
+        { name: 'cashay', target: '^0.22.0' },
         { name: 'graphql', target: '^0.7.1' }
       ])
     }.bind(this))

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "peerDependencies": {
     "cashay": "^0.21.0",
     "ember-browserify": "^1.1.13",
-    "ember-redux": "^1.7.0",
+    "ember-redux": "^1.9.0",
     "graphql": "^0.7.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "cashay": "^0.21.0",
+    "cashay": "^0.22.0",
     "ember-ajax": "^2.4.1",
     "ember-browserify": "^1.1.13",
     "ember-cli": "2.9.1",
@@ -49,15 +49,14 @@
     "ember-addon"
   ],
   "dependencies": {
-    "babel-runtime": "^6.18.0",
-    "broccoli-cashay-schema": "^0.2.4",
+    "broccoli-cashay-schema": "^0.2.5",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
     "ember-cli-babel": "^5.1.7",
     "ember-fetch": "1.3.0"
   },
   "peerDependencies": {
-    "cashay": "^0.21.0",
+    "cashay": "^0.22.0",
     "ember-browserify": "^1.1.13",
     "ember-redux": "^1.9.0",
     "graphql": "^0.7.1",


### PR DESCRIPTION
No longer needed.  Requirement was dropped upstream.  See https://github.com/mattkrick/cashay/pull/140.