### PR TITLE
Drop browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,12 @@ If everything went well, you should have a GraphQL schema in `graphql-server/sch
 
 Once installed, you can use Cashay anywhere.
 
-Import Cashay using browserify:
-
-```js
-import npmCashay from 'npm:cashay';
-
-const { cashay } = npmCashay;
-```
-
 
 ### Example query
 
 ```js
+import { cashay } from 'cashay';
+
 let { users } = cashay.query(`{ users { id, name } }`).data;
 ```
 
@@ -51,10 +45,9 @@ Once you get the hang of GraphQL queries, you'll want to start connecting the da
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
-import npmCashay from '../npm-shims/cashay';
+import { cashay } from 'cashay';
 
 const { Component } = Ember;
-const { cashay } = npmCashay;
 
 
 const usersQuery = `

--- a/addon/http-transport.js
+++ b/addon/http-transport.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import npmCashay from 'npm:cashay';
+import { cashay, HTTPTransport as CashayTransport } from 'cashay';
 import fetch from 'fetch';
 
 const { RSVP: { Promise } } = Ember;
@@ -22,7 +22,7 @@ const { RSVP: { Promise } } = Ember;
  * When ember-cli-mirage's dependency, Pretender, gets fetch support, this
  * class can likely be removed.
  */
-export default class HTTPTransport extends npmCashay.HTTPTransport {
+export default class HTTPTransport extends CashayTransport {
   constructor(...args) {
     super(...args);
     this.sendToServer = (request) => {

--- a/app/instance-initializers/ember-cashay.js
+++ b/app/instance-initializers/ember-cashay.js
@@ -1,9 +1,7 @@
-import npmCashay from 'npm:cashay';
+import { cashay } from 'cashay';
 import schema from '../graphql-client/schema';
 import HTTPTransport from 'ember-cashay/http-transport';
 import ENV from '../config/environment';
-
-const { cashay } = npmCashay;
 
 export function startCashay(appInstance) {
   const graphqlEndpoint = ENV['ember-cashay']['graphql-endpoint'];

--- a/app/reducers/cashay.js
+++ b/app/reducers/cashay.js
@@ -1,5 +1,3 @@
-import npmCashay from 'npm:cashay';
-
-const { cashayReducer } = npmCashay;
+import { cashayReducer } from 'cashay';
 
 export default cashayReducer;

--- a/blueprints/ember-cashay/files/graphql-server/schema.js
+++ b/blueprints/ember-cashay/files/graphql-server/schema.js
@@ -1,53 +1,51 @@
-export default function(graphql) {
-  const {
-    GraphQLObjectType,
-    GraphQLSchema,
-    GraphQLString
-  } = graphql;
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString
+} from 'graphql';
 
-  /* Add your object types here
+/* Add your object types here
 
-  // Example:
+// Example:
 
-  const User = new GraphQLObjectType({
-    name: 'User',
-    description: 'A user',
-    fields: {
-      id: { type: GraphQLID },
-      name: { type: GraphQLString }
-    }
-  });
+const User = new GraphQLObjectType({
+  name: 'User',
+  description: 'A user',
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString }
+  }
+});
 
-  */
+*/
 
-  const query = new GraphQLObjectType({
-    name: 'RootQueryType',
-    fields: {
-      /* Add your query fields here */
+const query = new GraphQLObjectType({
+  name: 'RootQueryType',
+  fields: {
+    /* Add your query fields here */
 
-      // Example:
+    // Example:
 
-      hello: {
-        type: GraphQLString,
-        resolve() {
-          return 'world';
-        }
+    hello: {
+      type: GraphQLString,
+      resolve() {
+        return 'world';
       }
-
-      /*
-
-      // Example using Mirage and the User type above
-
-      users: {
-        type: new GraphQLList(User),
-        resolve: (_parent, _args, { mirage }) => {
-          return mirage.users.all().models.map(model => model.attrs);
-        }
-      }
-
-      */
     }
-  });
 
-  return new GraphQLSchema({ query });
-}
+    /*
+
+    // Example using Mirage and the User type above
+
+    users: {
+      type: new GraphQLList(User),
+      resolve: (_parent, _args, { mirage }) => {
+        return mirage.users.all().models.map(model => model.attrs);
+      }
+    }
+
+    */
+  }
+});
+
+export default new GraphQLSchema({ query });

--- a/blueprints/ember-cashay/index.js
+++ b/blueprints/ember-cashay/index.js
@@ -7,13 +7,12 @@ module.exports = {
   afterInstall: function() {
     return this.addAddonsToProject({
       packages: [
-        { name: 'ember-browserify', target: '^1.1.13' },
-        { name: 'ember-redux', target: '^1.9.0' }
+        { name: 'ember-redux', target: '^1.10.0' },
+        { name: 'ember-graphql-shim', target: '^0.1.0' }
       ]
     }).then(function() {
       return this.addPackagesToProject([
-        { name: 'cashay', target: '^0.22.0' },
-        { name: 'graphql', target: '^0.7.1' }
+        { name: 'cashay', target: '^0.22.1' }
       ])
     }.bind(this))
   }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ var cashaySchema = require('broccoli-cashay-schema');
 var esTranspiler = require('broccoli-babel-transpiler');
 var merge = require('broccoli-merge-trees');
 var path = require('path');
-var graphql = require('graphql');
-var cashay = require('cashay');
 
 var WebpackWriter = require('broccoli-webpack');
 
@@ -72,8 +70,8 @@ module.exports = {
 
     // Add the client-safe schema
     var clientTree = cashaySchema(esTranspiler(this.graphqlDir), {
-      cashay: cashay,
-      graphql: graphql,
+      cashay: require('cashay'),
+      graphql: require('graphql'),
       clientSchemaPath: path.join(this.clientOutputDir, 'schema.js')
     });
     trees.push(clientTree);
@@ -83,24 +81,8 @@ module.exports = {
 
   treeForVendor: function(tree) {
     const cashayPath = path.dirname(require.resolve('cashay'));
-    const cashayNode = esTranspiler(cashayPath, {
-      babel: {
-        presets: ['stage-1']
-      }
-    });
     const cashayTree = new WebpackWriter([ cashayPath ], {
       entry: './index.js',
-      modules: {
-        /*
-        loaders: [{
-          test: /\.js$/,
-          loaders: ['babel-loader'],
-          query: {
-            presets: ['stage-1']
-          }
-        }]
-        */
-      },
       output: {
         library: 'cashay',
         libraryTarget: 'amd',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "cashay": "^0.22.0",
+    "cashay": "^0.22.1",
     "ember-ajax": "^2.4.1",
     "ember-browserify": "^1.1.13",
     "ember-changeset": "1.2.0",
@@ -38,10 +38,11 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-graphql-shim": "0.1.0",
     "ember-load-initializers": "^0.6.1",
     "ember-redux": "toranb/ember-redux",
     "ember-resolver": "^2.0.3",
-    "graphql": "^0.7.1",
+    "graphql": "0.8.2",
     "loader.js": "^4.0.10",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"
@@ -51,7 +52,7 @@
   ],
   "dependencies": {
     "broccoli-babel-transpiler": "^5.6.1",
-    "broccoli-cashay-schema": "^0.3.0",
+    "broccoli-cashay-schema": "^0.4.0",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-webpack": "^1.0.0",
@@ -59,10 +60,9 @@
     "ember-fetch": "1.3.0"
   },
   "peerDependencies": {
-    "cashay": "^0.22.0",
-    "ember-browserify": "^1.1.13",
+    "cashay": ">=0.22.0 <0.23.0",
     "ember-redux": "^1.9.0",
-    "graphql": "^0.7.1",
+    "graphql": ">=0.7.0 <0.9.0",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "broccoli-cashay-schema": "^0.3.0",
     "broccoli-funnel": "^1.0.7",
     "broccoli-merge-trees": "^1.1.4",
+    "broccoli-webpack": "^1.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-fetch": "1.3.0"
   },

--- a/tests/acceptance/crud-test.js
+++ b/tests/acceptance/crud-test.js
@@ -1,8 +1,6 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
-import npmCashay from 'npm:cashay';
-
-const { cashay } = npmCashay;
+import { cashay } from 'cashay';
 
 moduleForAcceptance('Acceptance | CRUD', {
   afterEach() {

--- a/tests/dummy/app/components/project-detail.js
+++ b/tests/dummy/app/components/project-detail.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
-import npmCashay from 'npm:cashay';
+import { cashay } from 'cashay';
 
 const { Component, Logger } = Ember;
-const { cashay } = npmCashay;
 
 const projectQuery = `
   {

--- a/tests/dummy/app/components/projects-list.js
+++ b/tests/dummy/app/components/projects-list.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
-import npmCashay from 'npm:cashay';
+import { cashay } from 'cashay';
 
 const { Component, Logger } = Ember;
-const { cashay } = npmCashay;
 
 const projectsQuery = `
   {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import npmCashay from 'npm:cashay';
+import { cashay } from 'cashay';
 
 const { Controller, Logger } = Ember;
-const { cashay } = npmCashay;
 
 export default Controller.extend({
   actions: {

--- a/tests/dummy/app/controllers/project.js
+++ b/tests/dummy/app/controllers/project.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import npmCashay from 'npm:cashay';
+import { cashay } from 'cashay';
 
 const { Controller, Logger } = Ember;
-const { cashay } = npmCashay;
 
 export default Controller.extend({
   actions: {

--- a/tests/dummy/graphql-server/schema.js
+++ b/tests/dummy/graphql-server/schema.js
@@ -1,138 +1,135 @@
-export default function(graphql) {
-  const {
-    GraphQLBoolean,
-    GraphQLList,
-    GraphQLSchema,
-    GraphQLObjectType,
-    GraphQLString,
-    GraphQLID,
-    GraphQLNonNull
-  } = graphql;
+import {
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLID,
+  GraphQLNonNull
+} from 'graphql';
 
+// QUERIES
 
-  // QUERIES
-
-  const Project = new GraphQLObjectType({
-    name: 'Project',
-    description: 'A group of todos working toward a common goal',
-    fields: () => ({
-      id: { type: GraphQLID },
-      name: { type: GraphQLString },
-      todos: {
-        type: new GraphQLList(Todo),
-        resolve: ({ id }, _args, { db }) => {
-          return db.todos.where({ projectId: id }).models.map(model => model.attrs);
-        }
+const Project = new GraphQLObjectType({
+  name: 'Project',
+  description: 'A group of todos working toward a common goal',
+  fields: () => ({
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    todos: {
+      type: new GraphQLList(Todo),
+      resolve: ({ id }, _args, { db }) => {
+        return db.todos.where({ projectId: id }).models.map(model => model.attrs);
       }
-    })
-  });
+    }
+  })
+});
 
-  const Todo = new GraphQLObjectType({
-    name: 'Todo',
-    description: 'Something that needs to be done',
-    fields: () => ({
-      id: { type: GraphQLID },
-      project: { type: Project },
-      createdAt: { type: GraphQLString },
-      description: { type: GraphQLString }
-    })
-  });
+const Todo = new GraphQLObjectType({
+  name: 'Todo',
+  description: 'Something that needs to be done',
+  fields: () => ({
+    id: { type: GraphQLID },
+    project: { type: Project },
+    createdAt: { type: GraphQLString },
+    description: { type: GraphQLString }
+  })
+});
 
-  const rootQuery = new GraphQLObjectType({
-    name: 'RootQuery',
-    fields: () => ({
-      projects: {
-        type: new GraphQLList(Project),
-        resolve: (_parent, _args, { db }) => {
-          console.log(`Reading all projects from database`);
-          return db.projects.all().models.map(model => model.attrs);
+const rootQuery = new GraphQLObjectType({
+  name: 'RootQuery',
+  fields: () => ({
+    projects: {
+      type: new GraphQLList(Project),
+      resolve: (_parent, _args, { db }) => {
+        console.log(`Reading all projects from database`);
+        return db.projects.all().models.map(model => model.attrs);
+      }
+    },
+    project: {
+      type: Project,
+      args: {
+        id: {
+          type: new GraphQLNonNull(GraphQLID),
+          description: 'The project ID for the desired project'
         }
       },
-      project: {
-        type: Project,
-        args: {
-          id: {
-            type: new GraphQLNonNull(GraphQLID),
-            description: 'The project ID for the desired project'
-          }
-        },
-        resolve: (_parent, { id }, { db }) => {
-          console.log(`Reading project ${id} from database`);
-          return db.projects.find(id).attrs;
-        }
+      resolve: (_parent, { id }, { db }) => {
+        console.log(`Reading project ${id} from database`);
+        return db.projects.find(id).attrs;
       }
-    })
-  });
+    }
+  })
+});
 
 
-  // MUTATIONS
+// MUTATIONS
 
-  const rootMutation = new GraphQLObjectType({
-    name: 'RootMutation',
-    fields: () => ({
-      createProject: {
-        type: Project,
-        description: 'Create a new project',
-        args: {
-          name: {
-            type: new GraphQLNonNull(GraphQLString),
-            description: 'The name of the new project'
-          },
-          description: {
-            type: GraphQLString,
-            description: 'The description of the new project'
-          }
+const rootMutation = new GraphQLObjectType({
+  name: 'RootMutation',
+  fields: () => ({
+    createProject: {
+      type: Project,
+      description: 'Create a new project',
+      args: {
+        name: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: 'The name of the new project'
         },
-        resolve(_parent, { name, description }, { db }) {
-          console.log(`Creating project in database`);
-          return db.create('project', { name, description }).attrs;
+        description: {
+          type: GraphQLString,
+          description: 'The description of the new project'
         }
       },
-      updateProject: {
-        type: Project,
-        description: 'Update an existing project',
-        args: {
-          id: {
-            type: new GraphQLNonNull(GraphQLID),
-            description: 'The project ID'
-          },
-          name: {
-            type: new GraphQLNonNull(GraphQLString),
-            description: 'The updated name of the project'
-          },
-          description: {
-            type: GraphQLString,
-            description: 'The updated description of the project'
-          }
+      resolve(_parent, { name, description }, { db }) {
+        console.log(`Creating project in database`);
+        return db.create('project', { name, description }).attrs;
+      }
+    },
+    updateProject: {
+      type: Project,
+      description: 'Update an existing project',
+      args: {
+        id: {
+          type: new GraphQLNonNull(GraphQLID),
+          description: 'The project ID'
         },
-        resolve(_parent, { id, name, description }, { db }) {
-          console.log(`Updating project ${id} in database`);
-          return db.projects.find(id).update({ name, description });
+        name: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: 'The updated name of the project'
+        },
+        description: {
+          type: GraphQLString,
+          description: 'The updated description of the project'
         }
       },
-      deleteProject: {
-        type: GraphQLBoolean,
-        description: 'Delete a project',
-        args: {
-          id: {
-            type: new GraphQLNonNull(GraphQLID),
-            description: 'The project ID'
-          }
-        },
-        resolve(_parent, { id }, { db }) {
-          console.log(`Deleting project ${id} from database`);
-          db.projects.find(id).destroy();
-          return true;
-        }
+      resolve(_parent, { id, name, description }, { db }) {
+        console.log(`Updating project ${id} in database`);
+        return db.projects.find(id).update({ name, description });
       }
-    })
-  });
+    },
+    deleteProject: {
+      type: GraphQLBoolean,
+      description: 'Delete a project',
+      args: {
+        id: {
+          type: new GraphQLNonNull(GraphQLID),
+          description: 'The project ID'
+        }
+      },
+      resolve(_parent, { id }, { db }) {
+        console.log(`Deleting project ${id} from database`);
+        db.projects.find(id).destroy();
+        return true;
+      }
+    }
+  })
+});
 
 
-  // SCHEMA
+// SCHEMA
 
-  return new GraphQLSchema({
-    query: rootQuery,
-    mutation: rootMutation
-  });
-}
+export default new GraphQLSchema({
+  query: rootQuery,
+  mutation: rootMutation
+});

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
-import buildSchema from '../graphql-server/schema';
-import npmGraphql from 'npm:graphql';
+import graphqlSchema from '../graphql-server/schema';
+import { graphql } from 'graphql';
 import { Response } from 'ember-cli-mirage';
 
 const { Logger, RSVP: { Promise } } = Ember;
-const graphqlSchema = buildSchema(npmGraphql);
-const { graphql } = npmGraphql;
 
 export default function() {
 

--- a/tests/unit/cashay-test.js
+++ b/tests/unit/cashay-test.js
@@ -1,9 +1,31 @@
 import { module, test } from 'ember-qunit';
 
-import { cashay } from 'cashay';
+import {
+  HTTPTransport,
+  Transport,
+  cashay,
+  cashayReducer,
+  transformSchema
+} from 'cashay';
 
 module('Unit | vendor imports | cashay');
 
+test('it exports HTTPTransport', function(assert) {
+  assert.ok(HTTPTransport);
+});
+
+test('it exports Transport', function(assert) {
+  assert.ok(Transport);
+});
+
 test('it exports cashay', function(assert) {
   assert.ok(cashay);
+});
+
+test('it exports cashayReducer', function(assert) {
+  assert.ok(cashayReducer);
+});
+
+test('it exports transformSchema', function(assert) {
+  assert.ok(transformSchema);
 });

--- a/tests/unit/cashay-test.js
+++ b/tests/unit/cashay-test.js
@@ -1,0 +1,9 @@
+import { module, test } from 'ember-qunit';
+
+import { cashay } from 'cashay';
+
+module('Unit | vendor imports | cashay');
+
+test('it exports cashay', function(assert) {
+  assert.ok(cashay);
+});


### PR DESCRIPTION
**BREAKING CHANGE**

Using webpack instead of browserify allows users to import graphql/cashay in the usual way.  Also, because we don't have to deal with the npm: prefix conflicting with node anymore, we no longer have to inject graphql into a schema function, we can just return the schema.